### PR TITLE
qfix: replace prefix registry-k8s to nsm

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,10 +89,10 @@ func main() {
 	startTime := time.Now()
 
 	// Get config from environment
-	if err := envconfig.Usage("registry_k8s", config); err != nil {
+	if err := envconfig.Usage("nsm", config); err != nil {
 		logrus.Fatal(err)
 	}
-	if err := envconfig.Process("registry_k8s", config); err != nil {
+	if err := envconfig.Process("nsm", config); err != nil {
 		logrus.Fatalf("error processing config from env: %+v", err)
 	}
 


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

## Motivation

Makes registry-k8s configuration in the style as other NSM apps.

Found in https://github.com/networkservicemesh/deployments-k8s/issues/8187